### PR TITLE
FIX: Removing startsWith when fetching DB caused sync issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.homelab.ringue</groupId>
 	<artifactId>cloud-archiver</artifactId>
-	<version>0.9.9-SNAPSHOT</version>
+	<version>0.9.9.003-SNAPSHOT</version>
 	<name>cloud-archiver</name>
 	<description>Uploads configured folder content (media) to archive on a cloud provider</description>
 	<properties>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /app
 RUN chown -R cloud-archiver:cloud-archiver /app
 
 # Copy your Java application JAR file into the container
-COPY ./*.jar /app/cloud-archiver.jar
+COPY ./cloud-archiver-0.9.9.002.jar /app/cloud-archiver.jar
 COPY ./application.yml /app/applicaiton.yml
 
 EXPOSE 8080

--- a/src/main/java/com/homelab/ringue/cloud/archiver/repository/FileCatalogItemRepository.java
+++ b/src/main/java/com/homelab/ringue/cloud/archiver/repository/FileCatalogItemRepository.java
@@ -15,7 +15,8 @@ import com.homelab.ringue.cloud.archiver.domain.FileCatalogItem;
 public interface FileCatalogItemRepository extends MongoRepository<FileCatalogItem,String>{
     Optional<FileCatalogItem> findById(String absolutePath);
     List<FileCatalogItem> findByFileNameContains(String fileName);
-    Page<FileCatalogItem> findByParentFolder(String parentFolder,Pageable pageable);
-    Page<FileCatalogItem> findByParentFolderAndArchiveDateAfterOrParentFolderAndArchiveDateBefore(
+    //Must use startsWith in order to be able to provide rootFolder and childs/childs/childs
+    Page<FileCatalogItem> findByParentFolderStartsWith(String parentFolder,Pageable pageable);
+    Page<FileCatalogItem> findByParentFolderStartsWithAndArchiveDateAfterOrParentFolderStartsWithAndArchiveDateBefore(
             String rootFolder, Date since, String rootFolder2, Date olderThan, Pageable catalogPages);
 }

--- a/src/main/java/com/homelab/ringue/cloud/archiver/service/NotificationService.java
+++ b/src/main/java/com/homelab/ringue/cloud/archiver/service/NotificationService.java
@@ -9,4 +9,6 @@ public interface NotificationService {
 
     void notifyError(String message);
 
+    void notifyInfoMessage(String message);
+
 }

--- a/src/main/java/com/homelab/ringue/cloud/archiver/service/impl/WebhookNotificationService.java
+++ b/src/main/java/com/homelab/ringue/cloud/archiver/service/impl/WebhookNotificationService.java
@@ -67,7 +67,17 @@ public class WebhookNotificationService implements NotificationService{
         if(notificationsConfig == null){
             return;
         }
+        //TODO: Make prefix configurable
         sendWebhookMessage(":x: "+message);
+    }
+
+    @Override
+    public void notifyInfoMessage(String message) {
+        if(notificationsConfig == null){
+            return;
+        }
+        //TODO: Make prefix configurable
+        sendWebhookMessage(":information_source: "+message);
     }
 
 }

--- a/src/test/java/com/homelab/ringue/cloud/archiver/service/impl/FileCatalogServiceImplTest.java
+++ b/src/test/java/com/homelab/ringue/cloud/archiver/service/impl/FileCatalogServiceImplTest.java
@@ -36,6 +36,7 @@ import com.homelab.ringue.cloud.archiver.exception.CloudBackupException;
 import com.homelab.ringue.cloud.archiver.repository.FileCatalogItemRepository;
 import com.homelab.ringue.cloud.archiver.repository.SyncSummaryRepository;
 import com.homelab.ringue.cloud.archiver.service.FileCatalogItemMapper;
+import com.homelab.ringue.cloud.archiver.service.NotificationService;
 
 public class FileCatalogServiceImplTest {
 
@@ -72,6 +73,9 @@ public class FileCatalogServiceImplTest {
     private CloudProviderFactory cloudProviderFactory;
 
     @Mock
+    private NotificationService notificationService;
+
+    @Mock
     private CloudProvider cloudProvider;
 
     @BeforeEach
@@ -81,7 +85,7 @@ public class FileCatalogServiceImplTest {
         Mockito.when(applicationProperties.getCloudProviderConfig()).thenReturn(cloudProviderConfig);
         Mockito.when(cloudProviderConfig.getType()).thenReturn(CloudProviders.NO_PROVIDER);
         Mockito.when(cloudProviderFactory.getCloudProvider(Mockito.any())).thenReturn(cloudProvider);
-        Mockito.when(fileCatalogItemRepository.findByParentFolder(Mockito.anyString(),Mockito.any())).thenReturn(fileCatalogPageMock);
+        Mockito.when(fileCatalogItemRepository.findByParentFolderStartsWith(Mockito.anyString(),Mockito.any())).thenReturn(fileCatalogPageMock);
     }
 
 
@@ -110,8 +114,9 @@ public class FileCatalogServiceImplTest {
                        .thenReturn(mockStream);
             serviceImplSpy.performLocationSync(scanLocationConfigMock);
         }
-        Mockito.verify(fileCatalogItemRepository,Mockito.times(cleanRemovedFromCloud?2:1)).findByParentFolder(Mockito.anyString(),Mockito.any());
+        Mockito.verify(fileCatalogItemRepository,Mockito.times(cleanRemovedFromCloud?2:1)).findByParentFolderStartsWith(Mockito.anyString(),Mockito.any());
         Mockito.verify(serviceImplSpy).processFileStreamForBackup(Mockito.any(),Mockito.any(),Mockito.any());
+        Mockito.verify(notificationService,Mockito.times(cleanRemovedFromCloud?2:1)).notifyInfoMessage(Mockito.anyString());
     }
 
 


### PR DESCRIPTION
- Fixed self-injected issue when removed startsWith as it prevents fetching all childs from DB
- Added notification info message at start of backup and cleanup